### PR TITLE
Check node version to determine which cwd to use

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ cmds.forEach(function (cmd) {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.cwd(),
+        cwd: process.versions.node < '8.0.0' ? process.cwd : process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })


### PR DESCRIPTION
`process.versions.node` is available at least as far back as Node 4.0 (Ubuntu 16 LTS). Also it doesn't look like the 3.0.0 tag was pushed up with the 3.0.0 npm release commit. #59 